### PR TITLE
sln and csproj: Only x86 platform

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --no-restore --arch x86
+      run: dotnet build --no-restore
 # Enable the next two lines if tests are added:
 #    - name: Test
 #      run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,26 @@
+name: .NET
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore --arch x86
+# Enable the next two lines if tests are added:
+#    - name: Test
+#      run: dotnet test --no-build --verbosity normal

--- a/FoxProDatabaseExtractor.sln
+++ b/FoxProDatabaseExtractor.sln
@@ -1,22 +1,25 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32104.313
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FoxProDatabaseExtractor", "src/FoxProDatabaseExtractor.csproj", "{004E1D6C-A3E1-422F-8FD2-038D59CE017B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FoxProDatabaseExtractor", "src\FoxProDatabaseExtractor.csproj", "{004E1D6C-A3E1-422F-8FD2-038D59CE017B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{004E1D6C-A3E1-422F-8FD2-038D59CE017B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{004E1D6C-A3E1-422F-8FD2-038D59CE017B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{004E1D6C-A3E1-422F-8FD2-038D59CE017B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{004E1D6C-A3E1-422F-8FD2-038D59CE017B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{004E1D6C-A3E1-422F-8FD2-038D59CE017B}.Debug|x86.ActiveCfg = Debug|x86
+		{004E1D6C-A3E1-422F-8FD2-038D59CE017B}.Debug|x86.Build.0 = Debug|x86
+		{004E1D6C-A3E1-422F-8FD2-038D59CE017B}.Release|x86.ActiveCfg = Release|x86
+		{004E1D6C-A3E1-422F-8FD2-038D59CE017B}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {73657A32-E189-41FB-A4C6-4EE006D02DB3}
 	EndGlobalSection
 EndGlobal

--- a/FoxProDatabaseExtractor.sln
+++ b/FoxProDatabaseExtractor.sln
@@ -12,6 +12,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{0DC1D02A-AEC9-4222-9CDE-C846F4769EC9}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{8A79BA1F-0D89-4860-8D6C-8EED4E229E42}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\dotnet.yml = .github\workflows\dotnet.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x86 = Debug|x86
@@ -25,6 +32,10 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{0DC1D02A-AEC9-4222-9CDE-C846F4769EC9} = {DD71D181-7200-486E-919E-84E1B8C35851}
+		{8A79BA1F-0D89-4860-8D6C-8EED4E229E42} = {0DC1D02A-AEC9-4222-9CDE-C846F4769EC9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {73657A32-E189-41FB-A4C6-4EE006D02DB3}

--- a/FoxProDatabaseExtractor.sln
+++ b/FoxProDatabaseExtractor.sln
@@ -5,6 +5,13 @@ VisualStudioVersion = 17.1.32104.313
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FoxProDatabaseExtractor", "src\FoxProDatabaseExtractor.csproj", "{004E1D6C-A3E1-422F-8FD2-038D59CE017B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DD71D181-7200-486E-919E-84E1B8C35851}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		LICENSE = LICENSE
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x86 = Debug|x86

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ Tool written in C# with .NET 6.0 that reads a FoxPro 9 database file and dump th
 - .NET 6.0 SDK: https://dotnet.microsoft.com/en-us/download/dotnet/6.0
 - Visual FoxPro 9.0 - Note that Microsoft [does not offer the installer anymore](https://docs.microsoft.com/en-us/previous-versions/visualstudio/foxpro/mt490121(v=msdn.10)).
 
+# Build
+
+Since Visual FoxPro 9.0 was built for x86 only, this project needs to be built for that platform as well.
+
+- If building from Visual Studio directly, the only platform specified in the solution is x86, so you can build directly into that platform without any manual changes.
+- If building using the `dotnet` command directly from the `src` folder, you need to pass the `--arch x86` arguments to force building in x86.
+
 # Usage
 
 ```

--- a/src/FoxProDatabaseExtractor.csproj
+++ b/src/FoxProDatabaseExtractor.csproj
@@ -3,6 +3,7 @@
         <TargetFramework>net6.0-windows</TargetFramework>
         <OutputType>Exe</OutputType>
         <Version>2.0.0</Version>
+        <Platforms>x86</Platforms>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="System.Data.OleDb" Version="6.0.0" />


### PR DESCRIPTION
Fixes https://github.com/ChayoteJarocho/FoxProDatabaseExtractor/issues/5

Note: When building `FoxProDatabaseExtractor.csproj` directly from within the `src` folder, `dotnet` doesn't fallback to `x86` by default as expected. The platform needs to be explicitly specified in the command.