### PR TITLE
Fix bug causing exception due to float values not being casted correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/bin
 **/obj
 **/*.csproj.user
+src/Properties/launchSettings.json

--- a/src/DataType.cs
+++ b/src/DataType.cs
@@ -2,20 +2,32 @@
 {
     /// <summary>
     /// Represents a FoxPro column data type.
+    /// The official documentation shows a total of 11 data types, but does not show the actual underlying integer values of each data type:
     /// https://docs.microsoft.com/en-us/sql/odbc/microsoft/visual-foxpro-field-data-types?view=sql-server-ver15
+    /// The integer data types were manually inspected and extracted from Microsoft Visual Fox Pro 9.
+    /// Also, aaccording to Microsoft Visual FoxPro 9, there are a total of 19 possible fields.
+    /// Those additional fields have their own unique name, but their underlying integer value is a duplicate of another existing one.
     /// </summary>
     public enum DataType
     {
-        Double    = 'B',
-        Character = 'C',
-        Date      = 'D',
-        Float     = 'F',
-        General   = 'G',
-        Integer   = 'I',
-        Logical   = 'L',
-        Memo      = 'M',
-        Numeric   = 'N',
-        DateTime  = 'T',
-        Currency  = 'Y',
+        Integer = 3,
+        Double = 5,
+        Currency = 6,
+        Logical = 11,
+        General = 128,
+        Character = 129,
+        Numeric = 131,
+        Date = 133,
+        DateTime = 135,
+        // Duplicate values:
+        //   IntegerAutoInc = 3
+        //   Blob = 128
+        //   MemoBin = 128
+        //   VarBinary = 128
+        //   CharacterBinary = 129
+        //   Memo = 129
+        //   VarChar = 129
+        //   VarCharBin = 129
+        //   Float = 131
     }
 }

--- a/src/FoxProColumn.cs
+++ b/src/FoxProColumn.cs
@@ -12,8 +12,8 @@
         /// <param name="dataType">The data type of the column.</param>
         public FoxProColumn(string name, DataType dataType)
         {
-            this.Name = name;
-            this.DataType = dataType;
+            Name = name;
+            DataType = dataType;
         }
 
         /// <summary>
@@ -33,5 +33,11 @@
             get;
             private set;
         }
+
+        /// <summary>
+        /// Returns the column name.
+        /// </summary>
+        /// <returns>A string representing the column name.</returns>
+        public override string ToString() => Name;
     }
 }

--- a/src/FoxProDatabaseExtractor.csproj
+++ b/src/FoxProDatabaseExtractor.csproj
@@ -4,6 +4,8 @@
         <OutputType>Exe</OutputType>
         <Version>2.0.0</Version>
         <Platforms>x86</Platforms>
+        <StartupObject>FoxProDatabaseExtractor.Program</StartupObject>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="System.Data.OleDb" Version="6.0.0" />

--- a/src/FoxProTable.cs
+++ b/src/FoxProTable.cs
@@ -25,35 +25,7 @@ namespace FoxProDatabaseExtractor
         // Contains all the user columns in this table.
         private readonly List<FoxProColumn> _foxProColumns;
 
-        /// <summary>
-        /// Initializes a new <see cref="FoxProTable"/> instance.
-        /// </summary>
-        /// <param name="connection">A valid FoxPro connection. Must have been already opened by the <see cref="FoxProDatabaseConnector"/>.</param>
-        /// <param name="row">The data row containing the current table's information.</param>
-        public FoxProTable(OleDbConnection connection, DataRow row)
-        {
-            _foxProConnection = connection;
-
-            Name = row["TABLE_NAME"].ToString();
-
-            Console.WriteLine($"  Extracting table '{Name}'...");
-            _columnsTable = _foxProConnection.GetSchema(
-                OleDbMetaDataCollectionNames.Columns,
-                new string[]
-                {
-                    null, // Catalog
-                    null, // Owner
-                    Name, // Table
-                    null  // Column
-                }
-            );
-
-            _foxProColumns = new List<FoxProColumn>();
-            ExtractColumns();
-
-            // SelectCommand depends on generating the columns first.
-            _foxProAdapter = new OleDbDataAdapter(SelectCommand, _foxProConnection);
-        }
+        private readonly string _selectCommand;
 
         /// <summary>
         /// Represents the table name.
@@ -65,116 +37,141 @@ namespace FoxProDatabaseExtractor
         }
 
         /// <summary>
+        /// Initializes a new <see cref="FoxProTable"/> instance.
+        /// </summary>
+        /// <param name="connection">A valid FoxPro connection. Must have been already opened by the <see cref="FoxProDatabaseConnector"/>.</param>
+        /// <param name="row">The data row containing the current table's information.</param>
+        public FoxProTable(OleDbConnection connection, DataRow row)
+        {
+            _foxProConnection = connection;
+
+            Name = row["TABLE_NAME"]?.ToString() ?? throw new NullReferenceException("TABLE_NAME was not found for the current row.");
+
+            Console.WriteLine($"  Extracting table '{Name}'...");
+            _columnsTable = _foxProConnection.GetSchema(
+                OleDbMetaDataCollectionNames.Columns,
+                new string[]
+                {
+                    string.Empty, // Catalog
+                    string.Empty, // Owner
+                    Name,         // Table
+                    string.Empty  // Column
+                }
+            );
+
+            _foxProColumns = new List<FoxProColumn>();
+            ExtractColumns();
+
+            // SelectCommand depends on generating the columns first.
+            _selectCommand = GetSelectCommand();
+            _foxProAdapter = new OleDbDataAdapter(_selectCommand, _foxProConnection);
+        }
+
+        /// <summary>
         /// Gets the list of column names of this FoxPro table in CSV style: in one line, with a special character as separator.
         /// </summary>
-        public string JoinedColumnNames
+        public string GetJoinedColumnNames()
         {
-            get
+            List<string> columnNames = new();
+
+            foreach (FoxProColumn column in _foxProColumns)
             {
-                List<string> columnNames = new();
-
-                foreach (FoxProColumn column in _foxProColumns)
-                {
-                    columnNames.Add(column.Name);
-                }
-
-                return string.Join(CsvSeparator, columnNames);
+                columnNames.Add(column.Name);
             }
+
+            return string.Join(CsvSeparator, columnNames);
         }
 
         /// <summary>
         /// Gets the list of column types of this FoxPro table in CSV style: in one line, with a special character as separator.
         /// </summary>
-        public string JoinedColumnTypes
+        public string GetJoinedColumnTypes()
         {
-            get
+            List<string> columnTypes = new();
+
+            foreach (FoxProColumn column in _foxProColumns)
             {
-                List<string> columnTypes = new();
-
-                foreach (FoxProColumn column in _foxProColumns)
-                {
-                    columnTypes.Add(column.DataType.ToString());
-                }
-
-                return string.Join(CsvSeparator, columnTypes);
+                columnTypes.Add(column.DataType.ToString());
             }
+
+            return string.Join(CsvSeparator, columnTypes);
         }
 
         /// <summary>
         /// Yields all the data rows of this FoxPro table in CSV style: in one line, with a special character as separator.
         /// </summary>
-        public IEnumerable<string> JoinedValuesRows
+        public IEnumerable<string> GetJoinedValuesRows()
         {
-            get
+            DataTable valuesTable = GetValuesTable();
+            List<string> rowValues = new();
+            foreach (DataRow row in valuesTable.Rows)
             {
-                foreach (DataRow row in ValuesTable.Rows)
+                rowValues.Clear();
+                foreach (object? rawValue in row.ItemArray)
                 {
-                    List<string> rowValues = new();
-
-                    foreach (object rawValue in row.ItemArray)
-                    {
-                        string safeValue = GetSafeValue(rawValue);
-                        rowValues.Add(safeValue);
-                    }
-
-                    string joinedValues = string.Join(CsvSeparator, rowValues.ToArray());
-
-                    yield return joinedValues;
+                    string safeValue = GetSafeValue(rawValue);
+                    rowValues.Add(safeValue);
                 }
+
+                string joinedValues = string.Join(CsvSeparator, rowValues.ToArray());
+                yield return joinedValues;
             }
         }
 
         /// <summary>
         /// Generates the SELECT command to extract all the values from this table.
         /// </summary>
-        private string SelectCommand =>  string.Format(FoxProDatabaseConnector.SelectCommandFormatString, SelectColumnNames, Name);
+        private string GetSelectCommand()
+        {
+            string columnNames = GetSelectColumnNames();
+            return string.Format(FoxProDatabaseConnector.SelectCommandFormatString, columnNames, Name);
+        }
 
         /// <summary>
         /// The values of this FoxPro table.
         /// </summary>
-        private DataTable ValuesTable
+        private DataTable GetValuesTable()
         {
-            get
+            Console.WriteLine(_selectCommand);
+
+            DataTable table = new();
+            try
             {
-                Console.WriteLine(SelectCommand);
-
-                DataTable table = new();
-                try
-                {
-                    _foxProAdapter.Fill(table);
-                }
-                catch
-                {
-                    _foxProConnection.Close();
-                    _foxProConnection.Dispose();
-                    throw;
-                }
-
-                return table;
+                _foxProAdapter.Fill(table);
             }
+            catch
+            {
+                _foxProConnection.Close();
+                _foxProConnection.Dispose();
+                throw;
+            }
+
+            return table;
         }
 
         /// <summary>
         /// Returns the columns of this FoxPro table as a comma-separated string, to be used in a SELECT command.
         /// </summary>
-        private string SelectColumnNames
+        private string GetSelectColumnNames()
         {
-            get
+            List<string> columnNames = new();
+
+            foreach (FoxProColumn column in _foxProColumns)
             {
-                List<string> columnNames = new();
-
-                foreach (FoxProColumn column in _foxProColumns)
+                // If float values are not collected as string, then 'OleDbDataAdapter.Fill(DataTable)' throws InvalidOperationException with the following message:
+                // "The provider could not determine the Decimal value. For example, the row was just created, the default for the Decimal column was not available, and the consumer had not yet set a new Decimal value."
+                string fixedName = column.DataType switch
                 {
-                    string fixedName = column.DataType switch
-                    {
-                        DataType.Numeric => $" VAL(STR({column.Name})) ",
-                        _ => column.Name,
-                    };
-                    columnNames.Add(fixedName);
-                }
+                    DataType.Integer or DataType.Logical or DataType.General or DataType.Character or DataType.Date or DataType.DateTime => column.Name,
+                    DataType.Double or DataType.Currency or DataType.Numeric => $" VAL(STR({column.Name})) ",
+                    _ => throw new NotSupportedException($"Column type not supported: {column.Name}"),
+                };
+                ;
 
-                return string.Join(',', columnNames);
+                columnNames.Add(fixedName);
             }
+
+            return string.Join(',', columnNames);
         }
 
         /// <summary>
@@ -185,11 +182,13 @@ namespace FoxProDatabaseExtractor
             Console.WriteLine("    Extracting columns...");
             foreach (DataRow row in _columnsTable.Rows)
             {
-                string name = row["COLUMN_NAME"].ToString();
+                string name = row["COLUMN_NAME"]?.ToString() ?? throw new NullReferenceException("COLUMN_NAME was null for current row.");
 
                 Console.WriteLine($"      Extracting column '{name}'...");
 
-                DataType dataType = (DataType)Enum.Parse(typeof(DataType), row["DATA_TYPE"].ToString());
+                string dataTypeName = row["DATA_TYPE"]?.ToString() ?? throw new NullReferenceException($"DATA_TYPE was null for current row with column name '{name}'.");
+
+                DataType dataType = (DataType)Enum.Parse(typeof(DataType), dataTypeName);
                 
                 FoxProColumn column = new(name, dataType);
 
@@ -206,9 +205,13 @@ namespace FoxProDatabaseExtractor
         /// </summary>
         /// <param name="rawValue">The original value of the row cell.</param>
         /// <returns>The string with any necessary modifications.</returns>
-        private static string GetSafeValue(object rawValue)
+        private static string GetSafeValue(object? rawValue)
         {
-            string safeValue = rawValue.ToString().Trim().Replace("\\", "\\\\");
+            if (rawValue == null)
+            {
+                throw new NullReferenceException("Cannot retrieve safe value for a null raw value.");
+            }
+            string safeValue = (rawValue.ToString() ?? string.Empty).Trim().Replace("\\", "\\\\");
 
             if (safeValue == "True")
             {
@@ -221,5 +224,11 @@ namespace FoxProDatabaseExtractor
 
             return safeValue;
         }
+
+        /// <summary>
+        /// Returns the table name.
+        /// </summary>
+        /// <returns>A string representing the table name.</returns>
+        public override string ToString() => Name;
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 
 namespace FoxProDatabaseExtractor
@@ -8,53 +10,9 @@ namespace FoxProDatabaseExtractor
         private const string ExtensionFoxProDB = ".dbc";
 
         /// <summary>
-        /// Iterates through all the FoxPro tables and saves each one of them in a CSV file.
+        /// Entry point.
         /// </summary>
-        private static void SaveFoxProTablesToCSVFiles(FoxProDatabaseConnector connector, string targetCsvDirFullPath)
-        {
-            Console.WriteLine("Creating target directory...");
-            Directory.CreateDirectory(targetCsvDirFullPath);
-            Console.WriteLine("Target directory successfully created.");
-
-            foreach (FoxProTable table in connector.FoxProTables)
-            {
-                string fileName = $"{table.Name}.csv";
-                string filePath = Path.Combine(targetCsvDirFullPath, fileName);
-
-                if(File.Exists(filePath))
-                {
-                    Console.WriteLine($"File '{fileName}' exists. Deleting...");
-                    File.Delete(filePath);
-                }
-
-                Console.WriteLine($"  Writing to file '{fileName}'...");
-
-                StreamWriter writer = File.CreateText(filePath);
-
-                writer.WriteLine(table.JoinedColumnTypes);
-                writer.WriteLine(table.JoinedColumnNames);
-                
-                foreach (string joinedValues in table.JoinedValuesRows)
-                {
-                    writer.WriteLine(joinedValues);
-                }
-                
-                writer.Close();
-
-                Console.WriteLine($"Finished writing file {filePath}.");
-            }
-        }
-
-        /// <summary>
-        /// Prints the usage example.
-        /// </summary>
-        private static void PrintHelpAndExit()
-        {
-            Console.WriteLine("Usage:");
-            Console.WriteLine($"{AppDomain.CurrentDomain.FriendlyName} database{ExtensionFoxProDB} TargetCsvDir/");
-            Environment.Exit(-1);
-        }
-
+        /// <param name="args">Command line arguments.</param>
         public static void Main(string[] args)
         {
             // Verify the command was executed with one argument
@@ -81,15 +39,77 @@ namespace FoxProDatabaseExtractor
             else if (Directory.Exists(targetCsvDirFullPath))
             {
                 Console.WriteLine($"Target directory already exists: {targetCsvDirFullPath}");
-                PrintHelpAndExit();
+                Console.Write("Would you like to delete the target directory and recreate it? [Y|N]: ");
+                string answer = Console.ReadLine() ?? "N";
+                if (answer.ToUpperInvariant() == "Y")
+                {
+                    Console.WriteLine($"Deleting target directory: {targetCsvDirFullPath}");
+                    Directory.Delete(targetCsvDirFullPath, recursive: true);
+                }
+                else
+                {
+                    PrintHelpAndExit();
+                }
             }
 
             using FoxProDatabaseConnector connector = new(databaseFullPath);
 
             SaveFoxProTablesToCSVFiles(connector, targetCsvDirFullPath);
-            
+
             Console.WriteLine("Finished! Press enter to exit.");
             Console.ReadLine();
+        }
+
+        /// <summary>
+        /// Iterates through all the FoxPro tables and saves each one of them in a CSV file.
+        /// </summary>
+        private static void SaveFoxProTablesToCSVFiles(FoxProDatabaseConnector connector, string targetCsvDirFullPath)
+        {
+            Console.WriteLine("Creating target directory...");
+            Directory.CreateDirectory(targetCsvDirFullPath);
+            Console.WriteLine("Target directory successfully created.");
+
+            foreach (FoxProTable table in connector.FoxProTables)
+            {
+                string fileName = $"{table.Name}.csv";
+                string filePath = Path.Combine(targetCsvDirFullPath, fileName);
+
+                if(File.Exists(filePath))
+                {
+                    Console.WriteLine($"File '{fileName}' exists. Deleting...");
+                    File.Delete(filePath);
+                }
+
+                Console.WriteLine($"  Writing to file '{fileName}'...");
+
+                StreamWriter writer = File.CreateText(filePath);
+
+                string joinedColumnTypes = table.GetJoinedColumnTypes();
+                writer.WriteLine(joinedColumnTypes);
+                string joinedColumnNames = table.GetJoinedColumnNames();
+                writer.WriteLine(joinedColumnNames);
+
+                IEnumerable<string> joinedValuesRows = table.GetJoinedValuesRows();
+                foreach (string joinedValues in joinedValuesRows)
+                {
+                    writer.WriteLine(joinedValues);
+                }
+                
+                writer.Close();
+
+                Console.WriteLine($"Finished writing file {filePath}.");
+            }
+        }
+
+        /// <summary>
+        /// Prints the usage example.
+        /// </summary>
+        [DoesNotReturn]
+        private static void PrintHelpAndExit()
+        {
+            Console.WriteLine("Usage:");
+            Console.WriteLine($"{AppDomain.CurrentDomain.FriendlyName} database{ExtensionFoxProDB} TargetCsvDir/");
+            Environment.Exit(-1);
         }
     }
 }


### PR DESCRIPTION
Fixes #6 

When a numeric/double/currency value cannot be casted using the specified `SELECT` command, then `OleDbDataAdapter.Fill(DataTable)` throws `InvalidOperationException` with the following message:

```
The provider could not determine the Decimal value. For example, the row was just created, the default for the Decimal column was not available, and the consumer had not yet set a new Decimal value.
```
The fix consists in converting all numeric values to string when selecting them, as described here: https://stackoverflow.com/questions/5048733/vb-net-visual-foxpro-ole-db-problem-with-numeric-decimal-column

Additional fixes in this PR:
- Convert properties that retrieve complex data into methods.
- Ask in `Program.Main` if the output folder should be deleted if it already exists.
- Enable nullability in the csproj and fix the warnings.